### PR TITLE
Fixed the algorithm that computes the latitude and the longitude of the cell centers

### DIFF
--- a/src/bathytools/bathymetry_config.py
+++ b/src/bathytools/bathymetry_config.py
@@ -166,27 +166,29 @@ class DomainGeometry:
         minimum longitude values.
 
         Returns:
-            int: The number of grid cells along the longitudinal direction calculated by
-            dividing the longitudinal range by the resolution.
+            The number of grid cells along the longitudinal direction
+            calculated by dividing the longitudinal range by the resolution.
         """
-        return int(
-            (self.maximum_longitude - self.minimum_longitude) / self.resolution
-        )
+        raw_number = (
+            self.maximum_longitude - self.minimum_longitude
+        ) / self.resolution
+        return int(round(raw_number))
 
     @property
     def n_y(self):
         """
-        Calculates the number of latitude grid points (n_y) based on the resolution
-        and given latitudinal boundaries. The value is computed by dividing the
-        difference between the maximum and minimum latitude by the spatial
-        resolution and rounding it to the nearest integer.
+        Calculates the number of latitude grid points (n_y) based on the
+        resolution and given latitudinal boundaries. The value is computed by
+        dividing the difference between the maximum and minimum latitude by
+        the spatial resolution and rounding it to the nearest integer.
 
         Returns:
-            int: The number of latitude grid points based on the input parameters.
+            The number of latitude grid points based on the input parameters.
         """
-        return int(
-            (self.maximum_latitude - self.minimum_latitude) / self.resolution
-        )
+        raw_number = (
+            self.maximum_latitude - self.minimum_latitude
+        ) / self.resolution
+        return int(round(raw_number))
 
     @property
     def longitude(self):
@@ -200,11 +202,8 @@ class DomainGeometry:
             numpy.ndarray: A NumPy array containing the linearly spaced
             longitude values.
         """
-        return np.linspace(
-            self.minimum_longitude + self.resolution * 0.5,
-            self.maximum_longitude - self.resolution * 0.5,
-            self.n_x,
-        )
+        steps = np.arange(self.n_x, dtype=np.float64) * self.resolution
+        return (self.minimum_longitude + self.resolution / 2.0) + steps
 
     @property
     def latitude(self):
@@ -216,13 +215,10 @@ class DomainGeometry:
 
         Returns:
             numpy.ndarray: A NumPy array containing the linearly spaced
-            longitude values.
+            latitude values.
         """
-        return np.linspace(
-            self.minimum_latitude + self.resolution * 0.5,
-            self.maximum_latitude - self.resolution * 0.5,
-            self.n_y,
-        )
+        steps = np.arange(self.n_y, dtype=np.float64) * self.resolution
+        return (self.minimum_latitude + self.resolution / 2.0) + steps
 
 
 class BathyInterpolationMethod(Enum):

--- a/src/bathytools/geoarrays.py
+++ b/src/bathytools/geoarrays.py
@@ -115,7 +115,10 @@ class GeoArrays:
         return x * y
 
     def _build_mesh_mask_mer(
-        self, water_fractions: WaterFractions, dtype=np.float64
+        self,
+        water_fractions: WaterFractions,
+        output_appendix: OutputAppendix,
+        dtype=np.float64,
     ) -> xr.Dataset:
         meridional_size, zonal_size = self.compute_metric_cell_size()
 
@@ -237,6 +240,8 @@ class GeoArrays:
         )
         mesh_mask.attrs.update(mer_mesh_mask_version="1.0")
 
+        output_appendix.apply_metadata(mesh_mask)
+
         return mesh_mask
 
     def build_mesh_mask(
@@ -248,7 +253,9 @@ class GeoArrays:
         new_e3t=True,
     ) -> xr.Dataset:
         if use_mer_format:
-            return self._build_mesh_mask_mer(water_fractions, dtype=dtype)
+            return self._build_mesh_mask_mer(
+                water_fractions, output_appendix=output_appendix, dtype=dtype
+            )
 
         meridional_size, zonal_size = self.compute_metric_cell_size()
 
@@ -306,7 +313,11 @@ class GeoArrays:
             ]
             mesh_mask_dict[var_name] = (dims, var_data.values)
 
-        return xr.Dataset(mesh_mask_dict)
+        final_output = xr.Dataset(mesh_mask_dict)
+
+        output_appendix.apply_metadata(final_output)
+
+        return final_output
 
     def build_mit_static_data(
         self, water_fractions: WaterFractions, dtype=np.float32

--- a/src/bathytools/output_appendix.py
+++ b/src/bathytools/output_appendix.py
@@ -51,6 +51,20 @@ class OutputAppendix:
         """
         self._meshmask_metadata[name] = content
 
+    def apply_metadata(self, mask: xr.Dataset):
+        """
+        Apply stored metadata to the given meshmask dataset.
+
+        This method updates the attributes of the provided xarray Dataset
+        in place using the metadata previously added via
+        `add_meshmask_metadata`.
+
+        Args:
+            mask: The meshmask xarray Dataset whose attributes will be
+                updated with the stored metadata.
+        """
+        mask.attrs.update(self._meshmask_metadata)
+
     def add_additional_variable(self, name: str, content: xr.DataArray):
         """
         Adds an xarray DataArray to the meshmask file.


### PR DESCRIPTION
In the previous version of Bathytools, the number of cells was computed by dividing the domain size by the resolution and then truncating the result to the largest integer smaller than the ratio. This could lead to unexpected behavior when the ratio was, for example, 39.9999…, where the user was clearly aiming for 40 cells but instead encountered a rounding error.

Additionally, the algorithm used to determine the cell centers could be inconsistent. It enforced the center of the first cell to be located at the beginning of the domain plus half the resolution, and the center of the last cell at the end of the domain minus half the resolution. The remaining centers were then computed by evenly spacing n points between the first and last centers. This approach could produce incorrect results, as nothing guaranteed that the resulting spacing still matched the intended resolution (even though this was implicitly assumed based on the first and last centers).

With this update, the number of cells is now computed by rounding the ratio to the nearest integer (so 39.999 is correctly rounded to 40). Moreover, cell centers are computed starting from the bottom-left corner of the domain (i.e., the corner with the smallest coordinate values) and advancing according to the specified resolution. This approach may introduce a slight mismatch with the desired position of the top-right corner of the domain, but it ensures that the resolution is respected up to the last significant digit.